### PR TITLE
Get rid of Rubygems deprecation warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gem 'activeresource', '~> 2.3'
 gem 'activesupport', '~> 2.3'


### PR DESCRIPTION
Without this, running `bundle` results in:

> The source :rubygems is deprecated because HTTP requests are insecure.
> Please change your source to 'https://rubygems.org' if possible, or 'http://rubygems.org' if not.
